### PR TITLE
Add flexible Mistral OCR and Tavily configurations with easy switching

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -64,6 +64,8 @@ data:
     gemini: "{{ .secrets.api_keys.gemini }}"
     jupyter_token: "{{ .secrets.api_keys.jupyter_token }}"
     qdrant: "{{ .secrets.api_keys.qdrant }}"
+    mistral_ocr: "{{ .secrets.api_keys.mistral_ocr }}"
+    tavily: "{{ .secrets.api_keys.tavily }}"
 
   # Service-specific configuration
   service_config:
@@ -102,3 +104,5 @@ secrets:
     gemini: "changeme"
     jupyter_token: "changeme"
     qdrant: "changeme-qdrant-api-key"
+    mistral_ocr: "changeme-mistral-ocr-key"
+    tavily: "tvly-changeme"

--- a/containers/systemd/openwebui/openwebui.env.tmpl
+++ b/containers/systemd/openwebui/openwebui.env.tmpl
@@ -21,14 +21,69 @@ REDIS_URL=redis://openwebui-redis:{{ .ports.redis }}/0
 OPENAI_API_BASE_URL=http://litellm:{{ .ports.litellm }}/v1
 OPENAI_API_KEY={{ .api_keys.litellm_master }}
 
-# Document Processing - uses service names
-CONTENT_EXTRACTION_ENGINE=docling
-DOCLING_SERVER_URL=http://docling:{{ .ports.docling }}
+# ============================================================================
+# Document Processing / OCR
+# ============================================================================
+# Choose ONE extraction engine by uncommenting the appropriate section:
+#
+# Option 1: Mistral OCR (API-based, superior for complex layouts)
+# - Requires MISTRAL_OCR_API_KEY in encrypted_private_secrets.yaml
+# - Best for: tables, multi-column, scientific papers
+# - Sign up: https://console.mistral.ai/
+#
+# Option 2: Docling (self-hosted container)
+# - Uses local docling container (no API key needed)
+# - Best for: privacy, offline operation
+# ============================================================================
 
-# Search - uses service name
-SEARXNG_QUERY_URL=http://searxng:{{ .ports.searxng }}/search?q=<query>
+# OPTION 1: Mistral OCR (API-based) - ACTIVE
+CONTENT_EXTRACTION_ENGINE=mistral_ocr
+MISTRAL_OCR_API_KEY={{ .api_keys.mistral_ocr }}
+
+# OPTION 2: Docling (self-hosted) - COMMENTED
+# Uncomment below and comment out Mistral OCR section to switch to Docling
+#CONTENT_EXTRACTION_ENGINE=docling
+#DOCLING_SERVER_URL=http://docling:{{ .ports.docling }}
+
+# ============================================================================
+# Web Search
+# ============================================================================
+# Choose ONE search engine by uncommenting the appropriate section:
+#
+# Option 1: Tavily (API-based, LLM-optimized search)
+# - Requires TAVILY_API_KEY in encrypted_private_secrets.yaml
+# - Best for: RAG, 1000 free queries/month, fast results
+# - Sign up: https://app.tavily.com/
+#
+# Option 2: SearXNG (self-hosted meta-search)
+# - Uses local searxng container (no API key needed)
+# - Best for: privacy, unlimited queries, self-hosted
+# ============================================================================
+
+# OPTION 1: Tavily (API-based) - ACTIVE
 ENABLE_RAG_WEB_SEARCH=true
-RAG_WEB_SEARCH_ENGINE=searxng
+RAG_WEB_SEARCH_ENGINE=tavily
+TAVILY_API_KEY={{ .api_keys.tavily }}
+
+# Web Search Settings (applies to all search engines)
+RAG_WEB_SEARCH_RESULT_COUNT=3
+RAG_WEB_SEARCH_CONCURRENT_REQUESTS=10
+ENABLE_SEARCH_QUERY=true
+
+# Web Loader (for loading full page content)
+RAG_WEB_LOADER_ENGINE=tavily_extract
+TAVILY_EXTRACT_DEPTH=basic
+
+# OPTION 2: SearXNG (self-hosted) - COMMENTED
+# Uncomment below and comment out Tavily section to switch to SearXNG
+#ENABLE_RAG_WEB_SEARCH=true
+#RAG_WEB_SEARCH_ENGINE=searxng
+#SEARXNG_QUERY_URL=http://searxng:{{ .ports.searxng }}/search?q=<query>
+#RAG_WEB_SEARCH_RESULT_COUNT=3
+#RAG_WEB_SEARCH_CONCURRENT_REQUESTS=10
+#ENABLE_SEARCH_QUERY=true
+# Note: For web loader with SearXNG, leave RAG_WEB_LOADER_ENGINE empty or set to "default"
+#RAG_WEB_LOADER_ENGINE=
 
 # Vector Database - Qdrant for RAG
 VECTOR_DB=qdrant


### PR DESCRIPTION
## Summary

Added flexible configuration for Mistral OCR and Tavily API services with easy switching between API-based and self-hosted alternatives.

## Changes

- Added `mistral_ocr` and `tavily` API keys to `.chezmoi.yaml.tmpl`
- Restructured `openwebui.env.tmpl` with clear option sections
- Document Processing: Mistral OCR (active) vs Docling (commented)
- Web Search: Tavily (active) vs SearXNG (commented)
- Added inline documentation for easy switching
- Included sign-up URLs and use-case guidance

## Benefits

**Mistral OCR**: Superior document extraction for complex layouts (tables, multi-column, scientific papers)
**Tavily**: LLM-optimized search with 1000 free queries/month
**Flexibility**: Easy switching between API-based and self-hosted services

Resolves #7

🤖 Generated with [Claude Code](https://claude.ai/code)